### PR TITLE
replace 'silence' with 'verbose' option

### DIFF
--- a/oaib/Batch.py
+++ b/oaib/Batch.py
@@ -38,8 +38,10 @@ class Batch:
         to `0.1`, which means the engine will wait until the current TPM drops
         below 90% of the limit, to prevent going over. This is necessary because
         we don't know how many tokens a response will contain before we get it.
-    silent : bool, default: `False`
-        If set to True, suppresses the progress bar and logging output.
+    verbose : int, default: `2`
+        If set to 0, suppresses the progress bar and logging output. If set to 1,
+        logs include metadata only. If set to 2, logs include both data and
+        metadata for each request.
     timeout : int, default: `60`
         The maximum time to wait for a single request to complete, in seconds.
     api_key : str, default: `os.environ.get("OPENAI_API_KEY")`
@@ -59,7 +61,7 @@ class Batch:
         tpm: int = 10_000,
         workers: int = 8,
         safety: float = 0.1,
-        silent: bool = False,
+        verbose: int = 2,
         timeout: int = 60,
         api_key: str or None = os.environ.get("OPENAI_API_KEY"),
         logdir: str or None = "oaib.txt",
@@ -70,13 +72,15 @@ class Batch:
             raise ValueError(
                 "No OpenAI API key found. Please provide an `api_key` parameter or set the `OPENAI_API_KEY` environment variable."
             )
+        if verbose > 2:
+            raise ValueError(f"Allowable `verbose` values are 0, 1, or 2; found {verbose}")
 
         self.client = AsyncOpenAI(api_key=api_key, **client_kwargs)
 
         self.rpm = rpm
         self.tpm = tpm
         self.safety = safety
-        self.silent = silent
+        self.verbose = verbose
         self.timeout = timeout
         self.logdir = logdir
         self.index = index
@@ -106,15 +110,16 @@ class Batch:
             file.write("")
 
     def log(self, *messages, worker: int or None = None):
-        now = datetime.now()
-        timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
+        if self.verbose > 0:
+            now = datetime.now()
+            timestamp = now.strftime("%Y-%m-%d %H:%M:%S")
 
-        for message in messages:
-            prefix = f"WORKER {worker}" if worker else "MAIN"
-            message = " | ".join([prefix.rjust(8), timestamp, message])
+            for message in messages:
+                prefix = f"WORKER {worker}" if worker else "MAIN"
+                message = " | ".join([prefix.rjust(8), timestamp, message])
 
-            with open(self.logdir, "a") as file:
-                file.write(message + "\n")
+                with open(self.logdir, "a") as file:
+                    file.write(message + "\n")
 
     async def _cleanup(self):
         """
@@ -186,7 +191,13 @@ class Batch:
 
     async def _process(self, request, i=None):
         endpoint, func, args, kwargs, metadata = request
-        self.log(f"PROCESSING | {kwargs}", worker=i)
+
+        if self.verbose == 1:
+            log_content = f"{metadata}"
+        else:
+            log_content = f"{metadata} | {kwargs}"
+
+        self.log(f"PROCESSING | {log_content}", worker=i)
 
         try:
             [response] = await wait_for(
@@ -313,20 +324,22 @@ class Batch:
             for i in range(self.__num_workers)
         }
 
+        silence = self.verbose == 0
+
         self.__progress.main = tqdm(
             total=self.__queue.qsize(),
-            unit='req', dynamic_ncols=True, disable=self.silent
+            unit='req', dynamic_ncols=True, disable=silence
         )
 
         self.__progress.rpm = tqdm(
             desc="RPM", total=self.rpm, unit='rpm',
-            dynamic_ncols=True, disable=self.silent,
+            dynamic_ncols=True, disable=silence,
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}"
         )
 
         self.__progress.tpm = tqdm(
             desc="TPM", total=self.tpm, unit='tpm',
-            dynamic_ncols=True, disable=self.silent,
+            dynamic_ncols=True, disable=silence,
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt}"
         )
 


### PR DESCRIPTION
I've found that the logs are pretty hard to work with when requests come with very long messages (in my case, on the order of 7k tokens). this PR expands the log verbosity options into 3 levels:
- `verbose=0`: suppress tqdm bars and 100% of log output (what the docstring says `silent=True` should do, although currently it doesn't suppress logs at all)
- `verbose=1`: display tqdm bars and log requests with metadata only
- `verbose=2`: display tqdm bars and log requests with metadata and all request params (including messages). this is roughly equivalent to current behavior of `silence=False`

I believe `verbose=1` is a more sensible default, but kept default `verbose=2` to align with the current behavior